### PR TITLE
Change Methods in InputSource to Abstract

### DIFF
--- a/EOCV-Sim/src/main/java/com/github/serivesmejia/eocvsim/input/InputSource.java
+++ b/EOCV-Sim/src/main/java/com/github/serivesmejia/eocvsim/input/InputSource.java
@@ -17,17 +17,13 @@ public abstract class InputSource {
         return false;
     }
 
-    public void reset() {
-    }
+    public abstract void reset();
 
-    public void close() {
-    }
+    public abstract void close();
 
-    public void onPause() {
-    }
+    public abstract void onPause();
 
-    public void onResume() {
-    }
+    public abstract void onResume();
 
     public Mat update() {
         return null;

--- a/EOCV-Sim/src/main/java/com/github/serivesmejia/eocvsim/input/source/ImageSource.java
+++ b/EOCV-Sim/src/main/java/com/github/serivesmejia/eocvsim/input/source/ImageSource.java
@@ -52,6 +52,10 @@ public class ImageSource extends InputSource {
     }
 
     @Override
+    public void onResume() {
+    }
+
+    @Override
     public void reset() {
 
         if (!initialized) return;


### PR DESCRIPTION
Since `InputSource` was abstract, and there were four methods that had no actual body, I believe it makes for sense for them to be abstract methods. `ImageSource` did not implement `onResume()` but I believe that is intentional; therefore, that is a decision made for the `ImageSource`, rather than something shared by all `InputSource` subclasses.