### PR TITLE
Fix MatRecycler crashes

### DIFF
--- a/EOCV-Sim/src/main/java/org/openftc/easyopencv/MatRecycler.java
+++ b/EOCV-Sim/src/main/java/org/openftc/easyopencv/MatRecycler.java
@@ -88,11 +88,6 @@ public class MatRecycler {
 
     public int getAvailableMats() { return availableMats.size(); }
 
-    @Override
-    public void finalize() {
-        releaseAll();
-    }
-
     public final class RecyclableMat extends Mat {
 
         private int idx = -1;


### PR DESCRIPTION
This finalize override caused the sim to crash with random native errors for reasons that I do not fully comprehend. Regardless, this shouldn't even be necessary because the gc already handles deleting the native objects.